### PR TITLE
Fix Python 3.6 installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 - '3.3'
 - '3.4'
 - '3.5'
+- '3.6'
 env:
   global:
   - LD_LIBRARY_PATH=./libsecp256k1_ext/.libs
@@ -50,6 +51,22 @@ matrix:
   - os: linux
     language: python
     python: 3.5
+    sudo: required
+    services:
+    - docker
+    env:
+    - BUNDLED=1
+    - BUILD_LINUX_WHEELS=1
+  - os: osx
+    language: generic
+    osx_image: xcode7.1
+    python: 3.6
+    env:
+    - TRAVIS_PYTHON_VERSION=3.6
+    - BUNDLED=1
+  - os: linux
+    language: python
+    python: 3.6
     sudo: required
     services:
     - docker

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ from setup_support import absolute, build_flags, has_system_lib
 
 # Version of libsecp256k1 to download if none exists in the `libsecp256k1`
 # directory
-LIB_TARBALL_URL = "https://github.com/bitcoin-core/secp256k1/archive/c5b32e16c4d2560ce829caf88a413fc06fd83d09.tar.gz"
+LIB_TARBALL_URL = "https://github.com/bitcoin-core/secp256k1/archive/c95f6f1360a87bba61622cbaa0eb714c241a5d90.tar.gz"
 
 
 # We require setuptools >= 3.3


### PR DESCRIPTION
Fix installation for python 3.6 by using newer _libsecp256k1_ version (latest verified commit, solution found from issue #22).